### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+RUN pip install --no-cache youtube-dl
+
+COPY ./dlnap/ /usr/src/dlnap/
+WORKDIR /usr/src/dlnap/
+
+ENTRYPOINT [ "./dlnap.py" ]


### PR DESCRIPTION
Add Dockerfile to enable image building. Useful for development and tests under Docker workflow.
Using the official Python 3 image, latest tag. More info at https://hub.docker.com/_/python/
 
Just adding files, setting working dir and running install and build instructions.
 
Build:
 
```
$ docker build -t dlnap .
```
 
Run:
 
```
$ docker run --rm -it dlnap [options...]
```
 
FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:
 
```
$ docker run --rm -it pataquets/dlnap [options...]
```
 
Using `--rm` causes container it to be deleted after stop and `-it` makes the container not to go background and run interactively.
 
Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a ~free~ paid Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.